### PR TITLE
Tweaks: add overlay to usrbg and increase contrast

### DIFF
--- a/midnight/css/base.css
+++ b/midnight/css/base.css
@@ -343,6 +343,9 @@ TABLE OF CONTENTS
 
 	/*Toasts*/
 	--toast-background:var(--lv1);
+	
+	/*Profile*/
+	--user-gradient:linear-gradient(0deg, rgba(0,0,15,0.6054796918767507) 0%, rgba(0,0,0,0) 100%);
 }
 
 /*More Compatibility Variables*/
@@ -7490,7 +7493,7 @@ body .bd-toasts {
 	left:0;
 	width:100%;
 	height:100%;
-	background:var(--user-background) center/cover no-repeat;
+	background:var(--user-gradient), var(--user-background) center/cover no-repeat;
 	z-index:-1;
 	box-sizing:border-box;
 	box-shadow:inset 0 0 100vmax var(--lv1);


### PR DESCRIPTION
Creates an overlay that helps contrast custom user backgrounds from foreground text.

### Before
![Screenshot_20201027_170601](https://user-images.githubusercontent.com/42302831/97367194-b4980000-1876-11eb-88f2-d234b6fd7696.png)

### After
![Screenshot_20201027_170647](https://user-images.githubusercontent.com/42302831/97367273-cf6a7480-1876-11eb-8299-9d9844742c45.png)
