### PR TITLE
Tweak: Increase margin between status and badges

### DIFF
--- a/midnight/css/base.css
+++ b/midnight/css/base.css
@@ -5329,6 +5329,7 @@ html.theme-light body.bd-minimal #app-mount::before {
 .activityUserPopout-2yItg2 .textRow-19NEd_,
 .customStatus-1bh2V9 {
 	font-size: var(--size1);
+	margin-bottom:6px;
 }
 
 .barInner-3NDaY_ {


### PR DESCRIPTION
![Screenshot_20201027_171102](https://user-images.githubusercontent.com/42302831/97367589-66cfc780-1877-11eb-83dc-f1b3c8698357.png)


When adding `.date-YN6TCS + .customStatus-1bh2V9{margin-bottom:6px;}`
![Screenshot_20201027_171140](https://user-images.githubusercontent.com/42302831/97367653-7d761e80-1877-11eb-8c02-c01eb24b1390.png)
