### PR TITLE
Fix emoji/sticker buttons leaking above text area

### DIFF
--- a/midnight/css/base.css
+++ b/midnight/css/base.css
@@ -4506,7 +4506,7 @@ Removes the need to fix overlapping with member list*/
 	position: fixed;
 	right: 0;
 	bottom: 0;
-	height: 52px;
+	height: 50px; /*This should match the height of the text area*/
 	display:flex;
     justify-content:center;
 	align-items:center;


### PR DESCRIPTION
![Screenshot_20201028_210931](https://user-images.githubusercontent.com/42302831/97516771-e043e480-1961-11eb-8b4d-8b53aa41a8b3.png)

This region must be 50px otherwise it goes outside of the text area